### PR TITLE
[FIX: #73] : Added Resend Activation Link Functionality on the Registration Page

### DIFF
--- a/src/app/(authentication)/auth/register/page.tsx
+++ b/src/app/(authentication)/auth/register/page.tsx
@@ -217,12 +217,20 @@ const RegisterForm: React.FC = () => {
           </Button>
         </form>
 
-        <p className="text-gray-800 res-text-sm dark:text-gray-300">
-          Already have an account?{' '}
-          <Link href="/auth/login" className="text-brand hover:underline">
-            Login
-          </Link>
-        </p>
+        <div className="mt-4 res-text-sm">
+          <p className="text-gray-800 res-text-sm dark:text-gray-300">
+            Already have an account?{' '}
+            <Link href="/auth/login" className="text-brand hover:underline">
+              Login
+            </Link>
+          </p>
+          <p className="text-gray-800 res-text-sm dark:text-gray-300">
+            Already registered but not activated?{' '}
+            <Link href="/auth/resendverificationemail" className="text-brand hover:underline">
+              Resend Activation Link
+            </Link>
+          </p>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Title: [FIX: #73] : Added Resend Activation Link Functionality on the Registration Page

Description: Users who might have registered but not activated their accounts see a message saying, "Registered but not activated - check email for verification link," but there was no way to resend the activation link. There is an option on the login page for the same but none on the registration page. This PR adds the 'resend activation link' option on the registration page as well. 

Screenshots (if any):
<img width="1326" alt="Screenshot 2025-03-11 at 1 29 20 AM" src="https://github.com/user-attachments/assets/c6699189-e2b0-410d-a333-16035d0046f0" />
<img width="1373" alt="Screenshot 2025-03-11 at 1 30 13 AM" src="https://github.com/user-attachments/assets/3be19f55-da14-4e9f-b95a-2676a17f16ef" />
<img width="974" alt="Screenshot 2025-03-11 at 1 30 38 AM" src="https://github.com/user-attachments/assets/3965a3d2-2c5c-4eaa-a183-bee47926cc38" />


Resolves #73 
