### PR TITLE
Add smooth transitions to comment button

### DIFF
--- a/src/app/(main)/(posts)/posts/[postId]/page.tsx
+++ b/src/app/(main)/(posts)/posts/[postId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 
 import Image from 'next/image';
 
@@ -36,6 +36,7 @@ const PostDetailPage = ({ params }: { params: { postId: number } }) => {
   const requestConfig = accessToken ? { headers: { Authorization: `Bearer ${accessToken}` } } : {};
   const { data, isLoading } = usePostsApiGetPost(params.postId);
   const imageData = useIdenticon(40);
+  const [showComments, setShowComments] = useState(false);
 
   const { data: reactions, refetch: refetchLikes } = useUsersCommonApiGetReactionCount(
     'posts.post',
@@ -181,10 +182,20 @@ const PostDetailPage = ({ params }: { params: { postId: number } }) => {
                 )}
                 <span className="text-xs">{reactions?.data.dislikes}</span>
               </button>
-              <button className="flex items-center space-x-1 transition hover:text-green-500">
+
+              {/* <button className="flex items-center space-x-1 transition hover:text-green-500">
+                <MessageCircle size={16} />
+                <span className="text-xs">{data.data.comments_count} comments</span>
+              </button> */}
+
+              <button
+                className="flex items-center space-x-1 transition hover:text-green-500"
+                onClick={() => setShowComments(!showComments)}
+              >
                 <MessageCircle size={16} />
                 <span className="text-xs">{data.data.comments_count} comments</span>
               </button>
+
               <SocialShare
                 url={`${window.location.origin}/posts/${params.postId}`}
                 title={data?.data?.title || 'Check out this post'}

--- a/src/components/common/RenderComments.tsx
+++ b/src/components/common/RenderComments.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import { ContentTypeEnum } from '@/api/schemas';
 
 import Comment, { CommentData } from './Comment';
@@ -23,22 +25,40 @@ const RenderComments: React.FC<RenderCommentsProps> = ({
   onDeleteComment,
   contentType,
 }) => {
+  const [shouldRender, setShouldRender] = useState(!isAllCollapsed);
+
+  useEffect(() => {
+    if (!isAllCollapsed) {
+      setShouldRender(true);
+    } else {
+      setTimeout(() => setShouldRender(false), 300); // Wait for animation to finish before unmounting
+    }
+  }, [isAllCollapsed]);
+
   return (
-    <>
-      {comments.map((comment) => (
-        <Comment
-          key={comment.id}
-          {...comment}
-          depth={depth}
-          maxDepth={maxDepth}
-          isAllCollapsed={isAllCollapsed}
-          onAddReply={onAddReply}
-          onUpdateComment={onUpdateComment}
-          onDeleteComment={onDeleteComment}
-          contentType={contentType}
-        />
-      ))}
-    </>
+    <div
+      className={`overflow-hidden transition-all duration-300 ease-in-out ${
+        isAllCollapsed ? 'max-h-0 opacity-0' : 'max-h-[1000px] opacity-100'
+      }`}
+    >
+      {shouldRender ? (
+        comments.map((comment) => (
+          <Comment
+            key={comment.id}
+            {...comment}
+            depth={depth}
+            maxDepth={maxDepth}
+            isAllCollapsed={isAllCollapsed}
+            onAddReply={onAddReply}
+            onUpdateComment={onUpdateComment}
+            onDeleteComment={onDeleteComment}
+            contentType={contentType}
+          />
+        ))
+      ) : (
+        <p className="text-sm text-gray-500">Comments are collapsed</p>
+      )}
+    </div>
   );
 };
 

--- a/src/components/posts/PostCard.tsx
+++ b/src/components/posts/PostCard.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -10,6 +12,7 @@ import {
   useUsersCommonApiGetReactionCount,
   useUsersCommonApiPostReaction,
 } from '@/api/users-common-api/users-common-api';
+import RedditStyleComments from '@/components/common/PostComments';
 import TruncateText from '@/components/common/TruncateText';
 import useIdenticon from '@/hooks/useIdenticons';
 import { showErrorToast } from '@/lib/toastHelpers';
@@ -23,6 +26,8 @@ const PostCard = (post: PostOut) => {
   dayjs.extend(relativeTime);
   const accessToken = useAuthStore((state) => state.accessToken);
   const imageData = useIdenticon(40);
+
+  const [showComments, setShowComments] = useState(false);
 
   const requestConfig = accessToken ? { headers: { Authorization: `Bearer ${accessToken}` } } : {};
 
@@ -88,38 +93,63 @@ const PostCard = (post: PostOut) => {
           </div>
         )}
 
-        <div className="flex items-center space-x-6 text-gray-500">
-          <button className="flex items-center space-x-1 transition hover:text-blue-500">
-            {data?.data?.user_reaction === 1 ? (
-              <ThumbsUp
-                size={20}
-                className="text-blue-500"
-                onClick={() => handleReaction('upvote')}
-              />
-            ) : (
-              <ThumbsUp size={20} onClick={() => handleReaction('upvote')} />
+        <div className="border-t border-gray-300 pt-4">
+          {/* Buttons Section */}
+          <div className="mb-4 flex items-center space-x-6 text-gray-500">
+            <button className="flex items-center space-x-1 transition hover:text-blue-500">
+              {data?.data?.user_reaction === 1 ? (
+                <ThumbsUp
+                  size={20}
+                  className="text-blue-500"
+                  onClick={() => handleReaction('upvote')}
+                />
+              ) : (
+                <ThumbsUp size={20} onClick={() => handleReaction('upvote')} />
+              )}
+              <span>{data?.data?.likes}</span>
+            </button>
+
+            <button className="flex items-center space-x-1 transition hover:text-red-500">
+              {data?.data.user_reaction === -1 ? (
+                <ThumbsDown
+                  size={20}
+                  className="text-red-500"
+                  onClick={() => handleReaction('downvote')}
+                />
+              ) : (
+                <ThumbsDown size={20} onClick={() => handleReaction('downvote')} />
+              )}
+            </button>
+
+            <button
+              className="flex items-center space-x-1 transition-all duration-500 ease-in-out hover:text-green-500"
+              onClick={() => setShowComments(!showComments)}
+            >
+              <MessageCircle size={16} />
+              <span>{post.comments_count} comments</span>
+            </button>
+
+            <button className="flex items-center space-x-1 transition hover:text-purple-500">
+              <Share2 size={16} />
+              <span>Share</span>
+            </button>
+          </div>
+
+          {/* Comments Section (Now Placed Below) */}
+          <div
+            className={`overflow-hidden transition-[max-height] duration-500 ease-in-out ${
+              showComments ? 'max-h-[1000px] opacity-100' : 'max-h-0 opacity-0'
+            }`}
+          >
+            {showComments && (
+              <div className="border-t border-gray-300 pt-4">
+                <h3 className="mb-4 text-lg font-semibold text-gray-500">Comments</h3>
+                <div className="space-y-4">
+                  <RedditStyleComments postId={post?.id ?? 0} />
+                </div>
+              </div>
             )}
-            <span>{data?.data?.likes}</span>
-          </button>
-          <button className="flex items-center space-x-1 transition hover:text-red-500">
-            {data?.data.user_reaction === -1 ? (
-              <ThumbsDown
-                size={20}
-                className="text-red-500"
-                onClick={() => handleReaction('downvote')}
-              />
-            ) : (
-              <ThumbsDown size={20} onClick={() => handleReaction('downvote')} />
-            )}
-          </button>
-          <button className="flex items-center space-x-1 transition hover:text-green-500">
-            <MessageCircle size={16} />
-            <span>{post.comments_count} comments</span>
-          </button>
-          <button className="flex items-center space-x-1 transition hover:text-purple-500">
-            <Share2 size={16} />
-            <span>Share</span>
-          </button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
fixes: #109

Title: Add smooth transitions to the comment button

Description: 

**Improved Comment Collapse/Expand with Smooth Transitions**

**What’s Changed?**
Added smooth transitions when collapsing/expanding comments in posts.

Made sure nested comments also expand/collapse smoothly.

Improved the comment button animation for a better user experience.

**Why?**
Previously, comments would appear/disappear instantly, making the UI feel abrupt.

Now, the transition feels more natural, improving readability and interaction.

**How?**
Used transition-all, max-height, and opacity for smooth effects.

Ensured interactions work well for nested comment threads.




Screenshots (if any): 

[smooth_transition-ezgif.com-video-to-gif-converter.webm](https://github.com/user-attachments/assets/2d3b93f2-9b17-42b2-9857-3b8f98ecf5ff)




Resolves #109 
