### PR TITLE
Fixed UI of Roles page and Hamburger in Mobile View

### DIFF
--- a/src/app/(main)/(articles)/article/[slug]/(articledashboard)/settings/EditArticleDetails.tsx
+++ b/src/app/(main)/(articles)/article/[slug]/(articledashboard)/settings/EditArticleDetails.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect } from 'react';
 
+import { useParams, useRouter } from 'next/navigation';
+
 import clsx from 'clsx';
 import { Controller, useForm } from 'react-hook-form';
 import { toast } from 'sonner';
@@ -33,6 +35,9 @@ interface EditArticleDetailsProps {
 }
 
 const EditArticleDetails: React.FC<EditArticleDetailsProps> = (props) => {
+  const router = useRouter();
+  const params = useParams<{ slug: string }>();
+
   const { title, abstract, authors, keywords, submissionType, defaultImageURL, articleId } = props;
   const {
     control,
@@ -92,6 +97,7 @@ const EditArticleDetails: React.FC<EditArticleDetailsProps> = (props) => {
   useEffect(() => {
     if (isSuccess) {
       toast.success('Article details updated successfully');
+      router.push(`/article/${params?.slug}`); // Redirect to the article page
     }
     if (updateError) {
       toast.error(`${updateError.response?.data.message}`);

--- a/src/app/(main)/(communities)/community/[slug]/(admin)/roles/page.tsx
+++ b/src/app/(main)/(communities)/community/[slug]/(admin)/roles/page.tsx
@@ -37,14 +37,19 @@ const Roles = ({ params }: { params: { slug: string } }) => {
   }, [error]);
 
   return (
-    <div className="flex flex-col">
-      <div className="self-start">
-        <TabComponent<ActiveTab>
-          tabs={['Members', 'Moderators', 'Reviewers', 'Admins']}
-          activeTab={activeTab}
-          setActiveTab={setActiveTab}
-        />
+    <div>
+      <div className="flex flex-col">
+        <div className="w-[310px] overflow-x-auto sm:w-full">
+          <div className="flex w-max gap-2 px-1">
+            <TabComponent<ActiveTab>
+              tabs={['Members', 'Moderators', 'Reviewers', 'Admins']}
+              activeTab={activeTab}
+              setActiveTab={setActiveTab}
+            />
+          </div>
+        </div>
       </div>
+
       {/* Todo: Reduce the number of lines of code */}
       {activeTab === 'Members' && (
         <div className="my-4 flex flex-col">

--- a/src/app/(main)/(users)/mycontributions/ContributionCard.tsx
+++ b/src/app/(main)/(users)/mycontributions/ContributionCard.tsx
@@ -20,7 +20,7 @@ const ContributionCard: React.FC<ContributionCardProps> = ({
       </div>
     </div>
     <div>
-      <h3 className="text-base font-semibold text-gray-800">{title}</h3>
+      <h3 className="text-base font-semibold text-dark-primary">{title}</h3>
       <p className="mt-1 text-2xl font-bold text-blue-600">{count}</p>
       <p className="mt-1 text-xs text-gray-600">{description}</p>
     </div>

--- a/src/app/(main)/(users)/mycontributions/ItemCard.tsx
+++ b/src/app/(main)/(users)/mycontributions/ItemCard.tsx
@@ -43,15 +43,14 @@ const ItemCard: React.FC<ItemCardProps> = ({
               : `/posts/${slug}`
         }
       >
-        <h4 className="text-sm font-semibold text-gray-800">{title}</h4>
+        <h4 className="text-sm font-semibold text-dark-primary">{title}</h4>
       </Link>
       <p className="text-xs text-gray-600">
         {role && memberCount ? `${role} · ${memberCount} members` : subtitle}
       </p>
       {type && (
         <span
-          className={`mt-1 inline-block rounded-full px-2 py-1 text-xs font-semibold 
-          ${
+          className={`mt-1 inline-block rounded-full px-2 py-1 text-xs font-semibold ${
             type === 'Article'
               ? 'bg-blue-100 text-blue-800'
               : type === 'Community'

--- a/src/app/(main)/(users)/mycontributions/ProfileHeader.tsx
+++ b/src/app/(main)/(users)/mycontributions/ProfileHeader.tsx
@@ -24,7 +24,7 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({ name, image, bio, locatio
       />
     </div>
     <div className="text-center sm:text-left">
-      <h2 className="text-2xl font-bold text-gray-900">{name}</h2>
+      <h2 className="text-2xl font-bold text-dark-primary">{name}</h2>
       <p className="mt-2 max-w-2xl text-gray-600">{bio}</p>
       <div className="mt-4 flex flex-wrap justify-center gap-4 sm:justify-start">
         {location && (

--- a/src/app/(main)/(users)/mycontributions/page.tsx
+++ b/src/app/(main)/(users)/mycontributions/page.tsx
@@ -326,7 +326,7 @@ const ContributionsPage: React.FC = () => {
                 </div>
 
                 <div className="rounded-lg bg-white-primary p-4 shadow-md sm:p-6">
-                  <h2 className="mb-4 text-xl font-semibold">
+                  <h2 className="mb-4 text-xl font-semibold text-dark-primary">
                     {activeTab.charAt(0).toUpperCase() + activeTab.slice(1)}
                   </h2>
                   {tabContent[activeTab].length === 0 && (

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -22,6 +22,7 @@ interface SidebarProps {
 
 const Sidebar: React.FC<SidebarProps> = ({ baseHref, links }) => {
   const pathname = usePathname();
+  const [open, setOpen] = React.useState(false);
 
   return (
     <>
@@ -51,9 +52,9 @@ const Sidebar: React.FC<SidebarProps> = ({ baseHref, links }) => {
         </div>
       </div>
       <div className="fixed left-0 top-10 z-10 md:hidden">
-        <Sheet>
+        <Sheet open={open} onOpenChange={setOpen}>
           <SheetTrigger asChild>
-            <button className="px-2 py-4">
+            <button className="px-2 py-8">
               <Menu size={24} />
             </button>
           </SheetTrigger>
@@ -73,6 +74,7 @@ const Sidebar: React.FC<SidebarProps> = ({ baseHref, links }) => {
                 <Link
                   key={link.href}
                   href={link.href}
+                  onClick={() => setOpen(false)}
                   className={`flex items-center rounded-md px-4 py-2 ${
                     pathname === link.href ? 'bg-black text-white' : 'hover:bg-gray-200'
                   }`}


### PR DESCRIPTION
Title: Fixed UI of Roles page and Hamburger in Mobile View.  [Fix: #148]

Description: This PR fixes the UI of the Roles page under the Community's settings in Mobile view. Earlier, the tabs section below the navbar flows out of the screen, breaking the UI. This PR also fixes the Hamburger problem. Now, whenever you click on any hamburger option, it closes automatically, enhancing the user experience.

Screenshots (if any):


https://github.com/user-attachments/assets/cda0b146-b55f-44db-bba3-b9760297c044



Resolves #148 