### PR TITLE
[FIX: #150 ] Enhance Dark Mode Consistency in Contributions Page

### DIFF
--- a/src/app/(main)/(users)/mycontributions/ContributionCard.tsx
+++ b/src/app/(main)/(users)/mycontributions/ContributionCard.tsx
@@ -13,16 +13,16 @@ const ContributionCard: React.FC<ContributionCardProps> = ({
   count,
   description,
 }) => (
-  <div className="flex items-start space-x-3 rounded-lg bg-white-primary p-4 shadow-md">
+  <div className="flex items-start space-x-3 rounded-lg border border-common-contrast bg-common-cardBackground p-4 res-text-xs hover:shadow-md hover:shadow-common-minimal">
     <div className="rounded-full bg-blue-100 p-2">
       <div className="h-5 w-5 text-blue-500">
         <Icon />
       </div>
     </div>
     <div>
-      <h3 className="text-base font-semibold text-gray-800">{title}</h3>
+      <h3 className="text-base font-semibold text-text-primary">{title}</h3>
       <p className="mt-1 text-2xl font-bold text-blue-600">{count}</p>
-      <p className="mt-1 text-xs text-gray-600">{description}</p>
+      <p className="mt-1 text-xs text-text-secondary">{description}</p>
     </div>
   </div>
 );
@@ -30,7 +30,7 @@ const ContributionCard: React.FC<ContributionCardProps> = ({
 export default ContributionCard;
 
 export const ContributionCardSkeleton: React.FC = () => (
-  <div className="flex animate-pulse items-start space-x-3 rounded-lg bg-white-primary p-4 shadow-md">
+  <div className="flex animate-pulse items-start space-x-3 rounded-lg border border-common-contrast bg-common-cardBackground p-4 res-text-xs hover:shadow-md hover:shadow-common-minimal">
     <div className="rounded-full bg-blue-100 p-2">
       <div className="h-5 w-5 rounded-full bg-gray-300"></div>
     </div>

--- a/src/app/(main)/(users)/mycontributions/ItemCard.tsx
+++ b/src/app/(main)/(users)/mycontributions/ItemCard.tsx
@@ -28,7 +28,7 @@ const ItemCard: React.FC<ItemCardProps> = ({
   memberCount,
   slug,
 }) => (
-  <div className="mb-4 flex items-start space-x-3 rounded-lg bg-white-primary p-4 shadow">
+  <div className="mb-4 flex items-start space-x-3 rounded-lg border border-common-contrast bg-common-cardBackground p-4 res-text-xs hover:shadow-md hover:shadow-common-minimal">
     <div className={`flex-shrink-0 rounded-full p-2 ${iconColor}`}>
       <Icon className="h-5 w-5" />
     </div>
@@ -43,15 +43,14 @@ const ItemCard: React.FC<ItemCardProps> = ({
               : `/posts/${slug}`
         }
       >
-        <h4 className="text-sm font-semibold text-gray-800">{title}</h4>
+        <h4 className="text-sm font-semibold text-text-primary">{title}</h4>
       </Link>
-      <p className="text-xs text-gray-600">
+      <p className="text-xs text-text-secondary">
         {role && memberCount ? `${role} · ${memberCount} members` : subtitle}
       </p>
       {type && (
         <span
-          className={`mt-1 inline-block rounded-full px-2 py-1 text-xs font-semibold 
-          ${
+          className={`mt-1 inline-block rounded-full px-2 py-1 text-xs font-semibold ${
             type === 'Article'
               ? 'bg-blue-100 text-blue-800'
               : type === 'Community'

--- a/src/app/(main)/(users)/mycontributions/ProfileHeader.tsx
+++ b/src/app/(main)/(users)/mycontributions/ProfileHeader.tsx
@@ -13,7 +13,7 @@ interface ProfileHeaderProps {
 }
 
 const ProfileHeader: React.FC<ProfileHeaderProps> = ({ name, image, bio, location, website }) => (
-  <div className="mb-8 flex flex-col items-center space-y-4 rounded-lg bg-white-primary p-6 shadow-md sm:flex-row sm:items-start sm:space-x-6 sm:space-y-0">
+  <div className="mb-8 flex flex-col items-center space-y-4 rounded-lg border border-common-contrast bg-common-cardBackground p-6 hover:shadow-md hover:shadow-common-minimal sm:flex-row sm:items-start sm:space-x-6 sm:space-y-0">
     <div className="flex-shrink-0">
       <Image
         src={image}
@@ -24,11 +24,11 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({ name, image, bio, locatio
       />
     </div>
     <div className="text-center sm:text-left">
-      <h2 className="text-2xl font-bold text-gray-900">{name}</h2>
-      <p className="mt-2 max-w-2xl text-gray-600">{bio}</p>
+      <h2 className="text-2xl font-bold text-text-primary">{name}</h2>
+      <p className="mt-2 max-w-2xl text-text-secondary">{bio}</p>
       <div className="mt-4 flex flex-wrap justify-center gap-4 sm:justify-start">
         {location && (
-          <div className="flex items-center text-gray-600">
+          <div className="flex items-center text-text-secondary">
             <MapPin className="mr-1 h-4 w-4" />
             <span>{location}</span>
           </div>
@@ -49,7 +49,7 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({ name, image, bio, locatio
 export default ProfileHeader;
 
 export const ProfileHeaderSkeleton: React.FC = () => (
-  <div className="mb-8 flex animate-pulse flex-col items-center space-y-4 rounded-lg bg-white p-6 shadow-md sm:flex-row sm:items-start sm:space-x-6 sm:space-y-0">
+  <div className="mb-8 flex animate-pulse flex-col items-center space-y-4 rounded-lg border border-common-contrast bg-common-cardBackground p-6 shadow-md sm:flex-row sm:items-start sm:space-x-6 sm:space-y-0">
     <div className="flex-shrink-0">
       <div className="h-32 w-32 rounded-full bg-gray-300"></div>
     </div>

--- a/src/app/(main)/(users)/mycontributions/TabButton.tsx
+++ b/src/app/(main)/(users)/mycontributions/TabButton.tsx
@@ -9,7 +9,9 @@ interface TabButtonProps {
 const TabButton: React.FC<TabButtonProps> = ({ active, onClick, children }) => (
   <button
     className={`rounded-t-lg px-3 py-2 text-sm font-semibold ${
-      active ? 'bg-white text-blue-600' : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
+      active
+        ? 'bg-white text-blue-600'
+        : 'bg-common-cardBackground text-text-secondary hover:bg-common-minimal'
     }`}
     onClick={onClick}
   >

--- a/src/app/(main)/(users)/mycontributions/page.tsx
+++ b/src/app/(main)/(users)/mycontributions/page.tsx
@@ -248,7 +248,7 @@ const ContributionsPage: React.FC = () => {
   ]);
 
   return (
-    <div className="bg-gray-100 text-gray-900 res-text-sm">
+    <div className="bg-gray-100 text-gray-900 res-text-sm dark:bg-background dark:text-gray-100">
       {isPending && (
         <div className="mx-auto min-h-screen max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
           <ProfileHeaderSkeleton />
@@ -325,7 +325,7 @@ const ContributionsPage: React.FC = () => {
                   ))}
                 </div>
 
-                <div className="rounded-lg bg-white-primary p-4 shadow-md sm:p-6">
+                <div className="rounded-lg border border-common-contrast bg-background p-4 hover:shadow-md hover:shadow-common-minimal sm:p-6">
                   <h2 className="mb-4 text-xl font-semibold">
                     {activeTab.charAt(0).toUpperCase() + activeTab.slice(1)}
                   </h2>

--- a/src/components/articles/SubmitArticleForm.tsx
+++ b/src/components/articles/SubmitArticleForm.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-
 import {
   Control,
   Controller,
@@ -244,7 +243,7 @@ const SubmitArticleForm: React.FC<SubmitArticleFormProps> = ({
               {showPrivateCheckOption && (
                 <div className="flex items-center gap-2">
                   <Checkbox
-                    onCheckedChange={(checked) => onChange(checked ? 'Private' : 'Public')}
+                    onCheckedChange={(checked: boolean) => onChange(checked ? 'Private' : 'Public')}
                     checked={value === 'Private'}
                   />
                   <span className="text-sm text-text-secondary">


### PR DESCRIPTION
Title:  Enhanced Dark Mode Consistency in Contributions Page

Description: This PR addresses the UI inconsistencies observed in Contributions Page when switching to dark mode. Currently, the individual components change as per the theme however, the overall page background and some elements remain as it is, resulting in a mismatched visual appearance. 

Additionally, styling of components like Profile Header, Contribution Cards, Item Cards and Tab Buttons has been updated such that they align with the styling convention implemented in the website. 

Screenhots (if any):

Before 

![contributions_page_before](https://github.com/user-attachments/assets/55658b1a-eed9-49c1-99fc-18b28c7359ea)

After

![contributions_page_after](https://github.com/user-attachments/assets/28ee3dcb-866f-4f85-a7d2-9710af4881f2)

These changes are made to enhance the dark mode experience without breaking the existing implementation in light mode.

Resolves #150
