### PR TITLE
Fixed the broken profile image in the comment of posts. 

### DIFF
--- a/src/components/common/Comment.tsx
+++ b/src/components/common/Comment.tsx
@@ -161,12 +161,20 @@ const Comment: React.FC<CommentProps> = ({
           <div className="absolute bottom-1 left-2 top-10 w-[1px] bg-gray-300" />
         )}
         <Image
-          src={author.profile_pic_url || `data:image/png;base64,${imageData}`}
+          src={
+            author.profile_pic_url
+              ? `${process.env.NEXT_PUBLIC_BACKEND_URL}${author.profile_pic_url}`
+              : `data:image/png;base64,${imageData}`
+          }
           alt={author.username}
           width={32}
           height={32}
           className="rounded-full"
+          onError={(e) => {
+            e.currentTarget.src = `/default-avatar.png`; // fallback image in /public
+          }}
         />
+
       </div>
 
       <div className="flex-grow res-text-sm">


### PR DESCRIPTION
Title: Fixed the broken profile image in the comment of posts. 

Description: The profile image was broken in the comment of posts

Screenshots: 
![Screenshot (9)](https://github.com/user-attachments/assets/1eed1720-e4c2-4b17-bc48-f85eb750005f)


Resolves #155 
