### PR TITLE
Changed the page.tsx file in the createCommunity folder to automatically fetch the latest updates.

### DIFF
--- a/src/app/(main)/(communities)/createcommunity/page.tsx
+++ b/src/app/(main)/(communities)/createcommunity/page.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { Controller, useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 
@@ -43,6 +44,7 @@ const CreateCommunity: React.FC = () => {
   const [selectedType, setSelectedType] = useState<OptionType>('public');
   const [selectedPublicCommunitiesSettings, setSelectedPublicCommunitiesSettings] =
     useState('anyone_can_join');
+  const queryClient = useQueryClient(); // <-- Added
 
   const { mutate: createCommunity, isPending } = useCommunitiesApiCreateCommunity({
     request: {
@@ -51,8 +53,11 @@ const CreateCommunity: React.FC = () => {
       },
     },
     mutation: {
-      onSuccess: (data) => {
+      onSuccess: async (data) => {
         toast.success('Community created successfully! Redirecting to community page...');
+        // Invalidate queries so the communities page is always fresh
+        await queryClient.invalidateQueries({ queryKey: ['communities'] });
+        await queryClient.invalidateQueries({ queryKey: ['my_communities'] });
         // router.push(`/community/${data.data.slug}`);
         router.push(`/communities`);
       },


### PR DESCRIPTION
Title: While creating any community, the user needs to refresh the page to view the changes done.

Description: While the user creates a community, a toast pops and the page is being redirected to the communities page but the page is not automatically refreshed to show the latest community created by the user. The user has to reload the page to see the latest changes.

Screenhots (if any): 
![Screenshot (4)](https://github.com/user-attachments/assets/59893e08-2732-4e26-a507-f50e830a4bfd)


Resolves #183 
