### PR TITLE
[FIX: #257]: Resolving black background inconsistency in all three sections during scale down of page.

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -3,7 +3,7 @@ import NavBar from '@/components/common/NavBar';
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div vaul-drawer-wrapper="">
+    <div vaul-drawer-wrapper="" className="bg-common-background">
       <NavBar />
       <main className="flex-grow pb-16 md:pb-0">{children}</main>
       {/* <Footer /> */}


### PR DESCRIPTION
Title: Resolving black background inconsistency in all three sections during scale down of page.

Description: This PR fixes a mobile-specific visual issue where opening the bottom drawer with background scaling enabled caused a large dark/empty area to appear during the scale-down animation in light mode.
The issue was reproducible across multiple sections (Articles, Communities, Discussions).While the scaling interaction itself was working as intended, the layout did not consistently occupy the full viewport height during scaling, resulting in a visually distracting experience.

### What was changed
**1).** Ensured that the main layout wrapper consistently fills the viewport height on mobile.
**2).** Preserved the existing `shouldScaleBackground` behavior to retain the intended zoom-out interaction.
**3).** Avoided changes to drawer logic or animation to keep the fix focused and low-risk.
This results in a consistent and clean scaling experience across all sections in light mode.


Screenhots (if any):


https://github.com/user-attachments/assets/3d988a2f-2dc5-4127-8664-34dd59bd5f6e





Resolves #257 
