### PR TITLE
Refactor: Centralize Profile form validation with Zod

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.7",
     "@headlessui/tailwindcss": "^0.2.1",
+    "@hookform/resolvers": "^5.2.2",
     "@mdxeditor/editor": "^3.32.3",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-checkbox": "^1.1.4",

--- a/src/app/(main)/(users)/myprofile/ProfessionalStatus.tsx
+++ b/src/app/(main)/(users)/myprofile/ProfessionalStatus.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 
 import { Plus, Trash2 } from 'lucide-react';
-import { FieldErrors, useFieldArray, useFormContext } from 'react-hook-form';
+import { FieldErrors, useFieldArray, useFormContext, get } from 'react-hook-form';
 
 import FormInput from '@/components/common/FormInput';
 import { Button, ButtonIcon, ButtonTitle } from '@/components/ui/button';
-import { statusSchema, yearSchema } from '@/constants/zod-schema';
 
 import { IProfileForm } from './page';
 
@@ -35,10 +34,11 @@ const ProfessionalStatus: React.FC<ProfessionalStatusProps> = ({ errors, editMod
         const statusFieldName = `professionalStatuses.${index}.status` as keyof IProfileForm;
         const startYearFieldName = `professionalStatuses.${index}.startYear` as keyof IProfileForm;
         const endYearFieldName = `professionalStatuses.${index}.endYear` as keyof IProfileForm;
+        const startYearError = get(errors, startYearFieldName);
+        const endYearError = get(errors, endYearFieldName);
+        const statusError = get(errors, statusFieldName);
 
         const watchedOngoing = watch(`professionalStatuses.${index}.isOngoing`);
-        const startYearValue = watch(`professionalStatuses.${index}.startYear`);
-
         const isOngoing = watchedOngoing;
 
         return (
@@ -51,7 +51,6 @@ const ProfessionalStatus: React.FC<ProfessionalStatusProps> = ({ errors, editMod
                   type="text"
                   register={register}
                   errors={errors}
-                  schema={statusSchema}
                   readOnly={!editMode}
                 />
               </div>
@@ -63,7 +62,6 @@ const ProfessionalStatus: React.FC<ProfessionalStatusProps> = ({ errors, editMod
                   type="text"
                   register={register}
                   errors={errors}
-                  schema={yearSchema}
                   readOnly={!editMode}
                 />
               </div>
@@ -76,18 +74,7 @@ const ProfessionalStatus: React.FC<ProfessionalStatusProps> = ({ errors, editMod
                     type="text"
                     register={register}
                     errors={errors}
-                    schema={yearSchema}
                     readOnly={!editMode}
-                    validateFn={(value: string) => {
-                      if (isOngoing) return true;
-                      if (!value) return 'End year is required';
-                      const start = parseInt(startYearValue, 10);
-                      const end = parseInt(value, 10);
-                      if (!isNaN(start) && !isNaN(end) && end < start) {
-                        return 'End year must be after start year';
-                      }
-                      return true;
-                    }}
                   />
                 ) : (
                   <div className="flex flex-col">
@@ -127,6 +114,11 @@ const ProfessionalStatus: React.FC<ProfessionalStatusProps> = ({ errors, editMod
                 </Button>
               )}
             </div>
+            {(startYearError || endYearError || statusError) && (
+              <div className="mt-2 text-functional-red res-text-xs">
+                {statusError?.message || startYearError?.message || endYearError?.message}
+              </div>
+            )}
           </div>
         );
       })}

--- a/src/app/(main)/(users)/myprofile/ResearchInterests.tsx
+++ b/src/app/(main)/(users)/myprofile/ResearchInterests.tsx
@@ -3,15 +3,15 @@ import React from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
 import MultiLabelSelector from '@/components/common/MultiLabelSelector';
-import { Option } from '@/components/ui/multiple-selector';
-import { researchInterestItemSchema } from '@/constants/zod-schema';
 
 interface ResearchInterestsProps {
   editMode: boolean;
 }
 
 const ResearchInterests: React.FC<ResearchInterestsProps> = ({ editMode }) => {
-  const { control } = useFormContext();
+  const { control, formState: { errors } } = useFormContext();
+  const researchErrors = errors.researchInterests as unknown as any[];
+  const firstError = researchErrors?.find?.((err) => err?.label?.message)?.label?.message;
 
   return (
     <div className="mx-auto mt-6 max-w-4xl rounded-xl border border-common-contrast bg-common-cardBackground p-4 md:p-6">
@@ -22,19 +22,6 @@ const ResearchInterests: React.FC<ResearchInterestsProps> = ({ editMode }) => {
       <Controller
         name="researchInterests"
         control={control}
-        rules={{
-          validate: (value: Option[]) => {
-            if (!value || value.length === 0) return true;
-
-            for (const item of value) {
-              const result = researchInterestItemSchema.safeParse(item.label);
-              if (!result.success) {
-                return result.error.issues[0]?.message ?? 'Invalid research interest';
-              }
-            }
-            return true;
-          },
-        }}
         render={({ field, fieldState }) => (
           <MultiLabelSelector
             disabled={!editMode}
@@ -47,6 +34,11 @@ const ResearchInterests: React.FC<ResearchInterestsProps> = ({ editMode }) => {
           />
         )}
       />
+      {firstError && (
+        <div className="mt-2 text-functional-red res-text-xs">
+          {firstError}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/app/(main)/(users)/myprofile/page.tsx
+++ b/src/app/(main)/(users)/myprofile/page.tsx
@@ -15,6 +15,8 @@ import { useCurrentUser, useInvalidateCurrentUser } from '@/hooks/useCurrentUser
 import useIdenticon from '@/hooks/useIdenticons';
 import { showErrorToast } from '@/lib/toastHelpers';
 import { useAuthStore } from '@/stores/authStore';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { profileMasterSchema } from '@/constants/zod-schema';
 
 import PersonalLinks from './PersonalLinks';
 import ProfessionalStatus from './ProfessionalStatus';
@@ -53,6 +55,7 @@ const Home: React.FC = () => {
   const { invalidateUser } = useInvalidateCurrentUser();
 
   const methods = useForm<IProfileForm>({
+    resolver: zodResolver(profileMasterSchema),
     defaultValues: {
       professionalStatuses: [],
     },
@@ -97,16 +100,16 @@ const Home: React.FC = () => {
        Why: Validation allowed whitespace-only optional links and untrimmed status text, which could be sent as raw spaces.
        How: Trim link/status/year strings once at submit-time and use normalized values for validation + API payload. */
     const normalizedLinks = {
-      homePage: formData.homePage.trim(),
-      linkedIn: formData.linkedIn.trim(),
-      github: formData.github.trim(),
-      googleScholar: formData.googleScholar.trim(),
+      homePage: formData.homePage?.trim() || '',
+      linkedIn: formData.linkedIn?.trim() || '',
+      github: formData.github?.trim() || '',
+      googleScholar: formData.googleScholar?.trim() || '',
     };
     const normalizedStatuses = formData.professionalStatuses.map((status) => ({
       ...status,
-      status: status.status.trim(),
-      startYear: status.startYear.trim(),
-      endYear: status.endYear.trim(),
+      status: status.status?.trim() || '',
+      startYear: status.startYear?.trim() || '',
+      endYear: status.endYear?.trim() || '',
     }));
 
     const dataToSend = {
@@ -130,27 +133,6 @@ const Home: React.FC = () => {
        What: Harden submit-time year validation for professional statuses.
        Why: Non-numeric or malformed year strings could pass the previous Number/parse checks.
        How: Enforce 4-digit year format for start/end and keep range/order checks against the current year. */
-    const invalidYear = normalizedStatuses.some((s) => {
-      const currentYear = new Date().getFullYear();
-
-      if (!/^\d{4}$/.test(s.startYear)) return true;
-      const start = Number(s.startYear);
-      if (start < 1950 || start > currentYear) return true;
-
-      if (!s.isOngoing) {
-        if (!/^\d{4}$/.test(s.endYear)) return true;
-        const end = Number(s.endYear);
-        if (end < start) return true;
-        if (end > currentYear) return true;
-      }
-
-      return false;
-    });
-
-    if (invalidYear) {
-      toast.error('Enter valid years: use 4-digit years between 1950 and the current year.');
-      return;
-    }
 
     mutate({
       data: {

--- a/src/constants/zod-schema.tsx
+++ b/src/constants/zod-schema.tsx
@@ -171,12 +171,24 @@ export const urlSchema = z.string().superRefine((url, ctx) => {
    What: Add optional URL schema variants for profile link inputs.
    Why: Profile links are optional and should allow blank values without failing URL validation.
    How: Union strict URL validators with a trimmed-empty string schema so blank values pass while non-empty values stay strict. */
-const optionalEmptyStringSchema = z.string().trim().length(0);
+const emptyStringToUndefined = (val: unknown) => (val === '' ? undefined : val);
 
-export const optionalScholarUrlSchema = z.union([optionalEmptyStringSchema, scholarUrlSchema]);
-export const optionalGithubUrlSchema = z.union([optionalEmptyStringSchema, githubUrlSchema]);
-export const optionalLinkedInUrlSchema = z.union([optionalEmptyStringSchema, linkedInUrlSchema]);
-export const optionalUrlSchema = z.union([optionalEmptyStringSchema, urlSchema]);
+export const optionalScholarUrlSchema = z.preprocess(
+  emptyStringToUndefined,
+  scholarUrlSchema.optional()
+);
+export const optionalGithubUrlSchema = z.preprocess(
+  emptyStringToUndefined,
+  githubUrlSchema.optional()
+);
+export const optionalLinkedInUrlSchema = z.preprocess(
+  emptyStringToUndefined,
+  linkedInUrlSchema.optional()
+);
+export const optionalUrlSchema = z.preprocess(
+  emptyStringToUndefined,
+  urlSchema.optional()
+);
 
 export const passwordSchema = z
   .string({ error: 'Password must be a string' })
@@ -367,3 +379,69 @@ export const reviewSubjectSchema = z
   .min(1, { message: 'Subject is required' })
   .min(10, { message: 'Subject must be at least 10 characters' })
   .max(100, { message: 'Subject must not exceed 100 characters' });
+
+export const bioSchema = z
+  .string({ error: 'Bio must be a string' })
+  .max(500, { message: 'Bio must not exceed 500 characters' })
+  .optional();
+
+export const professionalStatusSchema = z.object({
+  status: z.string().trim().min(1, 'Status is required'),
+  startYear: z.string()
+    .regex(/^\d{4}$/, "Start year must be a 4-digit number (e.g., '2020')")
+    .refine((val) => {
+      const year = parseInt(val, 10);
+      return year >= 1950 && year <= new Date().getFullYear();
+    }, "Start year must be between 1950 and the current year"),
+  endYear: z.string().optional(),
+  isOngoing: z.boolean().optional().default(false),
+}).superRefine((data, ctx) => {
+  const currentYear = new Date().getFullYear();
+
+  if (!data.isOngoing) {
+    if (!data.endYear || !/^\d{4}$/.test(data.endYear)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['endYear'],
+        message: "Valid 4-digit end year is required",
+      });
+      return;
+    }
+    const start = parseInt(data.startYear, 10);
+    const end = parseInt(data.endYear, 10);
+    if (end > currentYear) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['endYear'],
+        message: "End year cannot be in the future",
+      });
+    }
+    if (end < start) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['endYear'],
+        message: "End year must be after start year",
+      });
+    }
+  }
+});
+
+export const profileMasterSchema = z.object({
+  username: usernameSchema,
+  firstName: nameSchema,
+  lastName: nameSchema,
+  email: emailSchema,
+  bio: z.string().max(500, "Bio must not exceed 500 characters").optional(),
+  homePage: z.preprocess((val) => (val === '' ? undefined : val), optionalUrlSchema),
+  linkedIn: z.preprocess((val) => (val === '' ? undefined : val), optionalLinkedInUrlSchema),
+  github: z.preprocess((val) => (val === '' ? undefined : val), optionalGithubUrlSchema),
+  googleScholar: z.preprocess((val) => (val === '' ? undefined : val), optionalScholarUrlSchema),
+  professionalStatuses: z.array(professionalStatusSchema),
+  researchInterests: z.array(
+    z.object({
+      label: researchInterestItemSchema,
+      value: z.string(),
+    })
+  ).default([]),
+  profilePicture: z.any().optional(),
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1798,6 +1798,13 @@
   resolved "https://registry.npmjs.org/@headlessui/tailwindcss/-/tailwindcss-0.2.1.tgz"
   integrity sha512-2+5+NZ+RzMyrVeCZOxdbvkUSssSxGvcUxphkIfSVLpRiKsj+/63T2TOL9dBYMXVfj/CGr6hMxSRInzXv6YY7sA==
 
+"@hookform/resolvers@^5.2.2":
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-5.2.2.tgz#5ac16cd89501ca31671e6e9f0f5c5d762a99aa12"
+  integrity sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==
+  dependencies:
+    "@standard-schema/utils" "^0.3.0"
+
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
   resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz"
@@ -4223,6 +4230,11 @@
   integrity sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==
   dependencies:
     "@sinonjs/commons" "^3.0.0"
+
+"@standard-schema/utils@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/utils/-/utils-0.3.0.tgz#3d5e608f16c2390c10528e98e59aef6bf73cae7b"
+  integrity sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==
 
 "@stitches/core@^1.2.6":
   version "1.2.8"


### PR DESCRIPTION
#### Refactored and centralized the validation layer for the User Profile form using Zod, addressed several underlying architectural issues along the way.

### Description: 
- Previously: validation logic was fragmented, some schemas were passed directly to inputs, custom validateFn props were used in `ProfessionalStatus.tsx` file and hardcoded date checks were inside the onSubmit handler in `page.tsx` file.
- I have constructed a `profileMasterSchema` where all validation rules are now centrally managed. `zodResolver(profileMasterSchema)` handles everything, allowing us to remove the scattered logic from the UI components.
- Optional url schemas were previously combined using `z.union([optionalEmptyString, url])`. This showed users a generic `Invalid Input` error if a user typed a partially invalid URL rather than our custom/specific error messages.
- Replaced the previous `z.union` approach with `z.preprocess` to convert empty strings ("") to undefined. This allows `.optional()` to work correctly without throwing misleading union errors.
- Updated the UI to correctly extract and display deep nested errors for arrays using `get()` from react-hook-form. Now Academic/Professional Status fields also show errors in the same way as other fields instead of just the generic toast error.
- Added `bioSchema` with 500 characters limit. 

#### Screenhots:

https://github.com/user-attachments/assets/93c144dc-36fc-4cac-9640-a845cc43d9d3

Resolves #302 