### PR TITLE
  Hide back button on home page and edit option on deleted reviews

### DIFF
--- a/src/components/articles/DiscussionCard.tsx
+++ b/src/components/articles/DiscussionCard.tsx
@@ -190,7 +190,7 @@ const DiscussionCard: React.FC<DiscussionCardProps> = ({
 
   // Check if user can resolve/unresolve (admin or discussion author)
   const canResolve = isCommunityArticle && (isAdmin || discussion.is_author);
-  const canEditDiscussion = !!discussion.is_author;
+  const canEditDiscussion = !!discussion.is_author && !discussion.deleted_at;
   const shouldShowActions = (canResolve || canEditDiscussion) && !isEditing;
 
   const { mutate: toggleResolved, isPending: isToggling } =

--- a/src/components/articles/ReviewCard.tsx
+++ b/src/components/articles/ReviewCard.tsx
@@ -168,7 +168,7 @@ const ReviewCard: FC<ReviewCardProps> = ({ review, refetch }) => {
               <div className="flex flex-col">
                 <span className="flex items-center gap-2 text-sm font-bold text-text-secondary">
                   {review.user.username}
-                  {review.is_author && (
+                  {review.is_author && !review.deleted_at && (
                     <>
                       <span className="text-[10px] font-normal text-text-tertiary">(You)</span>
                       {/* Fixed by Codex on 2026-02-15

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -225,18 +225,16 @@ const NavBar: React.FC = () => {
     <header className="sticky top-0 z-[1000] w-full border-b border-common-contrast/40 bg-common-background/70 text-text-primary backdrop-blur-md">
       <nav className="container mx-auto flex items-center justify-between px-4 py-2">
         <div className="flex items-center">
-          {pathname !== '/' && (
-            <button
-              type="button"
-              aria-label="Go back"
-              className="mr-4 flex size-8 items-center justify-center rounded-full text-primary hover:bg-common-minimal/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-functional-green/60"
-              onClick={() => {
-                router.back();
-              }}
-            >
-              <MoveLeft className="size-5" strokeWidth={1.5} />
-            </button>
-          )}
+          <button
+            type="button"
+            aria-label="Go back"
+            className="mr-4 flex size-8 items-center justify-center rounded-full text-primary hover:bg-common-minimal/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-functional-green/60"
+            onClick={() => {
+              router.back();
+            }}
+          >
+            <MoveLeft className="size-5" strokeWidth={1.5} />
+          </button>
           <div className="flex items-center gap-2">
             <Link href="/" className="flex items-center">
               <Image

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -225,21 +225,18 @@ const NavBar: React.FC = () => {
     <header className="sticky top-0 z-[1000] w-full border-b border-common-contrast/40 bg-common-background/70 text-text-primary backdrop-blur-md">
       <nav className="container mx-auto flex items-center justify-between px-4 py-2">
         <div className="flex items-center">
-          {/* Fixed by Codex on 2026-02-15
-              Who: Codex
-              What: Convert the back icon into a real button.
-              Why: Icon-only divs are not keyboard accessible or announced by screen readers.
-              How: Wrap the icon in a button with an aria-label and click handler. */}
-          <button
-            type="button"
-            aria-label="Go back"
-            className="mr-4 flex size-8 items-center justify-center rounded-full text-primary hover:bg-common-minimal/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-functional-green/60"
-            onClick={() => {
-              router.back();
-            }}
-          >
-            <MoveLeft className="size-5" strokeWidth={1.5} />
-          </button>
+          {pathname !== '/' && (
+            <button
+              type="button"
+              aria-label="Go back"
+              className="mr-4 flex size-8 items-center justify-center rounded-full text-primary hover:bg-common-minimal/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-functional-green/60"
+              onClick={() => {
+                router.back();
+              }}
+            >
+              <MoveLeft className="size-5" strokeWidth={1.5} />
+            </button>
+          )}
           <div className="flex items-center gap-2">
             <Link href="/" className="flex items-center">
               <Image


### PR DESCRIPTION
 Closes #312
  Closes #290

  ## NavBar — back button on root home page (#312)

  The `MoveLeft` back arrow was rendering on every page, including `/`
  where there's no history to go back to. Added a `pathname !== '/'`
  check so it only shows when you're somewhere navigable back from.

  ## ReviewCard — edit button visible on deleted reviews (#290)

  The edit pencil was shown whenever `review.is_author` was true, with
  no check for whether the review had been soft-deleted. `ReviewOut`
  exposes a `deleted_at` field — added `!review.deleted_at` to the
  condition so the edit option is hidden once a review is deleted.