### PR TITLE
fix: prevent navbar back button from navigating to external sources

### DIFF
--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -48,10 +48,20 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import NotificationDropdownContent from './NotificationDropdown';
 import NotificationToast from './NotificationToast';
 
+const internalHistory: string[] = [];
+let isBrowserNavigation = false;
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('popstate', () => {
+    isBrowserNavigation = true;
+  });
+}
+
 const NavBar: React.FC = () => {
   const isAuthenticated = useStore(useAuthStore, (state) => state.isAuthenticated);
   const user = useStore(useAuthStore, (state) => state.user);
   const pathname = usePathname();
+  const [canGoBack, setCanGoBack] = useState(false);
   const authHeaders = useAuthHeaders();
   const mentionOwnerUserId = useMentionNotificationsStore((state) => state.ownerUserId);
   const mentionItems = useMentionNotificationsStore((state) => state.mentions);
@@ -175,6 +185,21 @@ const NavBar: React.FC = () => {
     user?.id,
   ]);
 
+  useEffect(() => {
+    if (!pathname) return;
+    if (isBrowserNavigation) {
+      if (internalHistory.length > 1) {
+        internalHistory.pop();
+      }
+      isBrowserNavigation = false;
+    } else {
+      if (internalHistory[internalHistory.length - 1] !== pathname) {
+        internalHistory.push(pathname);
+      }
+    }
+    setCanGoBack(internalHistory.length > 1);
+  }, [pathname]);
+
   const isAshokaUser = user?.email?.endsWith('ashoka.edu.in') ?? false;
   const router = useRouter();
   /* Fixed by Codex on 2026-02-16
@@ -233,9 +258,15 @@ const NavBar: React.FC = () => {
           <button
             type="button"
             aria-label="Go back"
-            className="mr-4 flex size-8 items-center justify-center rounded-full text-primary hover:bg-common-minimal/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-functional-green/60"
+            disabled={!canGoBack}
+            className={cn(
+              "mr-4 flex size-8 items-center justify-center rounded-full text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-functional-green/60 transition-all",
+              canGoBack ? "hover:bg-common-minimal/60" : "opacity-30 cursor-not-allowed"
+            )}
             onClick={() => {
-              router.back();
+              if (canGoBack) {
+                router.back();
+              }
             }}
           >
             <MoveLeft className="size-5" strokeWidth={1.5} />


### PR DESCRIPTION
**Title:** Prevent navbar back button from navigating to external sources

**Description:**
Fixes an issue where the navbar's back button would navigate the user back to an external source like Google Search or a new tab if they had just landed on the application from there. It now correctly disables the back button when there is no internal navigation history.

**Previously:**

https://github.com/user-attachments/assets/146ca62d-cb99-4b41-8f7d-89ed84dda258

**Now after this update:**

https://github.com/user-attachments/assets/1c5d9f94-5518-44d2-a61b-8a956f7ef630



Resolves #312 
